### PR TITLE
Don't output colors when in a environment where they aren't supported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -273,6 +273,11 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+        },
         "commander": {
             "version": "2.20.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "nodejs"
     ],
     "dependencies": {
+        "color-support": "^1.1.3",
         "commander": "^2.19.0",
         "figlet": "^1.2.1",
         "glob": "7.1.3",

--- a/src/tscov/tscov.ts
+++ b/src/tscov/tscov.ts
@@ -2,7 +2,7 @@ import 'reflect-metadata'
 import minimist from 'minimist'
 import * as path from 'path'
 import * as packageJson from '../../package.json'
-import { red, green, cyan, white } from 'kleur'
+import { red, green, cyan, white, default as kleur } from 'kleur'
 
 import { inject, injectable } from 'inversify'
 import { CheckTypes } from './check-types'
@@ -10,6 +10,8 @@ import { Options } from './options'
 import { MinCoverage } from './min-coverage'
 
 const figlet = require('figlet')
+
+kleur.enabled = require('color-support').level;
 
 @injectable()
 export class Tscov {


### PR DESCRIPTION
Not all terminals can output colored text resulting in some weird formatting for colored output.

This PR auto detects color support based on the environment and makes sure to not include color formatting when it's not supported.

Ref: https://github.com/lukeed/kleur#conditional-support
Ref: https://www.npmjs.com/package/color-support