### PR TITLE
Remove node check for variableDeclaration of CatchClause

### DIFF
--- a/src/tscov/check-types.ts
+++ b/src/tscov/check-types.ts
@@ -837,7 +837,6 @@ export class CheckTypes {
           break
         case ts.SyntaxKind.CatchClause:
           const catchClause = node as ts.CatchClause
-          handleSingleNode(catchClause.variableDeclaration, file, sourceFile)
           handleSingleNode(catchClause.block, file, sourceFile)
           break
         case ts.SyntaxKind.PropertyAssignment:


### PR DESCRIPTION
Typing the variable argument to a catch clause is not allowed.

[Playground example of invalid syntax](http://www.typescriptlang.org/play/#code/C4JwngBA3gUBHABYgPYHcIDsCmGCiIqIAFAEQBmKKpAlDAL4QDGAhsE4hMdgFwQFEa0OBBYAbbCGBlJRWgyA).

<img width="563" alt="" src="https://user-images.githubusercontent.com/179/63626150-c026d180-c5b6-11e9-947e-07e67e7c6372.png">
