### PR TITLE
fix: removed error typing for try/catch block

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 The Liftr framework provides a structure and tools to build API's with TypeScript and express. This repo/package is for the coverage of types in TypeScript.
 
 [![tscov](https://img.shields.io/badge/dynamic/json.svg?label=tscov&prefix=%E2%89%A5&suffix=%&query=$.typeCoverage.minCoverage&uri=https%3A%2F%2Fraw.githubusercontent.com%2Fjeroenouw%2Fliftr-tscov%2Fmaster%2Fpackage.json)](https://github.com/jeroenouw/liftr-tscov)
-[![npmversion](https://img.shields.io/npm/v/tscov.svg)](https://github.com/jeroenouw/liftr-tscov)
-[![npmlicense](https://img.shields.io/npm/l/tscov.svg)](https://github.com/jeroenouw/liftr-tscov/blob/master/LICENSE/)
-[![downloads](https://img.shields.io/npm/dy/tscov.svg)](https://github.com/jeroenouw/liftr-tscov)
+[![npmversion](https://img.shields.io/npm/v/@liftr/tscov.svg)](https://github.com/jeroenouw/liftr-tscov)
+[![npmlicense](https://img.shields.io/npm/l/@liftr/tscov.svg)](https://github.com/jeroenouw/liftr-tscov/blob/master/LICENSE/)
+[![downloads](https://img.shields.io/npm/dy/@liftr/tscov.svg)](https://github.com/jeroenouw/liftr-tscov)
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@liftr/tscov",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "description": "Check the type coverage of any TypeScript project with this easy npm package",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/tscov/check-types.ts
+++ b/src/tscov/check-types.ts
@@ -650,7 +650,6 @@ export class CheckTypes {
         case ts.SyntaxKind.TryStatement:
           const tryStatement = node as ts.TryStatement
           handleSingleNode(tryStatement.tryBlock, file, sourceFile)
-          handleSingleNode(tryStatement.catchClause, file, sourceFile)
           handleSingleNode(tryStatement.finallyBlock, file, sourceFile)
           break
         case ts.SyntaxKind.DebuggerStatement:

--- a/src/tscov/tscov.ts
+++ b/src/tscov/tscov.ts
@@ -11,7 +11,7 @@ import { MinCoverage } from './min-coverage'
 
 const figlet = require('figlet')
 
-kleur.enabled = require('color-support').level;
+kleur.enabled = require('color-support').level
 
 @injectable()
 export class Tscov {


### PR DESCRIPTION
This is a fix for https://github.com/jeroenouw/liftr-tscov/issues/14. I removed the error typing from the try/catch block. It was correctly pointed out that this type is not possible.